### PR TITLE
blazegraph uses "bigdata" in its url

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Blazegraph JavaScript API",
   "license": "MIT",
   "author": "David Hérault <dherault@nelson.ai> (https://github.com/dherault)",
+  "contributors": [
+    "Viliam Simko <viliam.simko@gmail.com> (https://github.com/vsimko)"
+  ],
   "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\""

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const defaultOptions = {
 function getClient(options = {}) {
   // The "client" is just a collection of methods
   // with connection params passed as an URL
-  const { host, port, namespace } = Object.assign({}, defaultOptions, options);
+  const { host, port, namespace, blazename } = Object.assign({}, defaultOptions, options);
   const blazegraphUrl = `http://${host}:${port}/${blazename}/namespace/${namespace}/sparql`;
   const passUrl = fn => (...args) => fn(blazegraphUrl, ...args);
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,14 @@ const defaultOptions = {
   host: 'localhost',
   port: 9999,
   namespace: 'kb',
+  blazename: 'bigdata', // it was 'blazegraph' before
 };
 
 function getClient(options = {}) {
   // The "client" is just a collection of methods
   // with connection params passed as an URL
   const { host, port, namespace } = Object.assign({}, defaultOptions, options);
-  const blazegraphUrl = `http://${host}:${port}/blazegraph/namespace/${namespace}/sparql`;
+  const blazegraphUrl = `http://${host}:${port}/${blazename}/namespace/${namespace}/sparql`;
   const passUrl = fn => (...args) => fn(blazegraphUrl, ...args);
 
   const boundMethods = {};


### PR DESCRIPTION
- the docker image does that: https://hub.docker.com/r/lyrasis/blazegraph/
- the docs mention that as well: https://wiki.blazegraph.com/wiki/index.php/REST_API